### PR TITLE
 Fixs and tests for name problem :snake:

### DIFF
--- a/namedtupled/integrations.py
+++ b/namedtupled/integrations.py
@@ -8,15 +8,15 @@ import getpass
 def load_lists(keys=[], values=[], name='NT'):
     """ Map namedtuples given a pair of key, value lists. """
     mapping = dict(zip(keys, values))
-    return mapper(mapping, name=name)
+    return mapper(mapping, _nt_name=name)
 
 
 def load_json(data=None, path=None, name='NT'):
     """ Map namedtuples with json data. """
     if data and not path:
-        return mapper(json.loads(data), name=name)
+        return mapper(json.loads(data), _nt_name=name)
     if path and not data:
-        return mapper(json.load(path), name=name)
+        return mapper(json.load(path), _nt_name=name)
     if data and path:
         raise ValueError('expected one source and received two')
 
@@ -24,11 +24,11 @@ def load_json(data=None, path=None, name='NT'):
 def load_yaml(data=None, path=None, name='NT'):
     """ Map namedtuples with yaml data. """
     if data and not path:
-        return mapper(yaml.load(data), name=name)
+        return mapper(yaml.load(data), _nt_name=name)
     if path and not data:
         with open(path, 'r') as f:
             data = yaml.load(f)
-        return mapper(data, name=name)
+        return mapper(data, _nt_name=name)
     if data and path:
         raise ValueError('expected one source and received two')
 

--- a/namedtupled/namedtupled.py
+++ b/namedtupled/namedtupled.py
@@ -3,19 +3,19 @@ standard_library.install_aliases()
 from collections import Mapping, namedtuple, UserDict
 
 
-def mapper(mapping, name='NT'):  # thank you https://gist.github.com/hangtwenty/5960435
+def mapper(mapping, _nt_name='NT'):
     """ Convert mappings to namedtuples recursively. """
     if isinstance(mapping, Mapping) and not isinstance(mapping, AsDict):
         for key, value in list(mapping.items()):
             mapping[key] = mapper(value)
-        return namedtuple_wrapper(name, **mapping)
+        return namedtuple_wrapper(_nt_name, **mapping)
     elif isinstance(mapping, list):
         return [mapper(item) for item in mapping]
     return mapping
 
 
-def namedtuple_wrapper(name, **kwargs):
-    wrap = namedtuple(name, kwargs)
+def namedtuple_wrapper(_nt_name, **kwargs):
+    wrap = namedtuple(_nt_name, kwargs)
     return wrap(**kwargs)
 
 

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -11,7 +11,8 @@ mapping = {
         'frobnicator': ['this', 'is', 'not', 'a', 'mapping']},
     'alist': [{'one': '1', 'a': 'A'}, {'two': '2', 'b': 'B'}],
     'huh': [('a', 'b', 'c')],
-    'huh2': ('a', 'b', ('a', 'b', 'c'))
+    'huh2': ('a', 'b', ('a', 'b', 'c')),
+    'name': 'Bob'
 }
 
 mapping_array = [mapping, mapping]
@@ -29,6 +30,7 @@ def test_namedtupled_map_object(mapping=mapping):
     assert t.alist[0] != {'one': '1', 'a': 'A'}
     assert t.huh == [('a', 'b', 'c')]
     assert t.huh2 == ('a', 'b', ('a', 'b', 'c'))
+    assert t.name == 'Bob'
 
 
 def test_namedtupled_map_array(mapping=mapping_array):


### PR DESCRIPTION
There was an error in the functions mapper and namedtuple_wrapper when the key "name" was used
Example:
```python
d = {'name': 'Person'}
```

So I changed the parameter's name to _nt_name 
I did not see problem in using a underscore at the beginning of the function and a nt is a convenction for namedtupled.


